### PR TITLE
Undefined name: import sys for line 124

### DIFF
--- a/network/model.py
+++ b/network/model.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 from .blocks import ResBlockDown, SelfAttention, ResBlock, ResBlockD, ResBlockUp, Padding
 import math
+import sys
 
 #components
 class Embedder(nn.Module):


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/vincent-thevenin/Realistic-Neural-Talking-Head-Models on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./network/model.py:123:13: F821 undefined name 'sys'
            sys.exit()
            ^
1     F821 undefined name 'sys'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree